### PR TITLE
Version 2.0

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,10 +2,10 @@
 <addon id="service.safestop"
        name="Safe Stop"
       version="2.0.0"
-      provider-name="enen92 - MOD by Solo0815">
+      provider-name="enen92, Solo0815">
     <requires>
-        <import addon="xbmc.addon" version="12.0.0"/>
-        <import addon="xbmc.python" version="2.1.0"/>
+		<import addon="xbmc.addon" version="14.0.0"/>
+		<import addon="xbmc.python" version="2.19.0"/>
     </requires>
     <extension point="xbmc.service" library="service.py" start="login"/>
     <extension point="xbmc.addon.metadata">

--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.safestop"
        name="Safe Stop"
-      version="1.0.0"
-      provider-name="enen92">
+      version="2.0.0"
+      provider-name="enen92 - MOD by Solo0815">
     <requires>
         <import addon="xbmc.addon" version="12.0.0"/>
         <import addon="xbmc.python" version="2.1.0"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-  <category label="General">
-		<!--<setting id="max_time" label="Maximum allowed playback time before asking to stop" type="slider" default="4" range="1,7" option="int" />-->
-		<setting id="max_time" label="Maximum allowed playback time (minutes) before asking to stop" type="labelenum" values="90|120|150|180|210|240|270|300|330|360|390|420"/>
-		<setting id="check_time" label="Service check time (minutes)" type="labelenum" values="1|3|5|10|15|20|25|30"/>
-		<setting id="waiting_time_dialog" label="Waiting time for the dialog (before stop) - seconds" type="labelenum" values="30|45|60|90|120|150|180"/>
-		<setting id="check_time_next" label="Next check time if dialog is cancelled (minutes)" type="labelenum" values="15|30|45|60|90|120"/>
-		<setting id="audio_change" label="Slow mute audio" type="bool" default="true" visible="true"/>
-		<setting type="sep"/>
+	<category label="General">
+		<setting id="check_time" label="Service check time (minutes)" default="5" type="labelenum" values="1|3|5|10|15|20|25|30"/>
+		<setting id="waiting_time_dialog" label="Waiting time for the dialog (before stop) (seconds)" type="labelenum" default="60" values="30|45|60|90|120|150|180"/>
+		<setting id="audio_change" label="Slow mute audio before stop playing" type="bool" default="true" visible="true"/>
+		<setting id="audio_change_rate" label="Time between 1% volume change  (millisec)" enable="eq(-1,true)" type="slider" default="500" range="50,50,3000" option="int"/>
+		<setting id="check_time_next" label="Next check time if dialog is cancelled (minutes)" default="30" type="labelenum" values="15|30|45|60|90|120"/>
+		<setting id="enable_screensaver" label="Enable Screensaver after stopping" type="bool" default="false" visible="true"/>
+	</category>
+	<category label="Audio/Video Supervision settings">
+		<setting id="video_enable" label="Enable Video Supervision" type="bool" default="true" visible="true"/>
+		<setting id="audio_enable" label="Enable Audio Supervision" type="bool" default="true" visible="true"/>
+		<setting label="Maximum Playing time (minutes) before asking to stop" type="lsep"/>
+		<setting id="max_time_video" label="Video Playbacktime" type="labelenum" default="150" enable="eq(-3,true)" values="90|120|150|180|210|240|270|300|330|360|390|420"/>
+		<setting id="max_time_audio" label="Audio Playbacktime" type="labelenum" default="150" enable="eq(-3,true)" values="90|120|150|180|210|240|270|300|330|360|390|420"/>
+	</category>
+	<category label="Debug">
 		<setting id="debug_mode" label="Debug mode" type="bool" default="false" visible="true"/>
-  </category>  
+		<setting label="'enable' debugging sets:" type="lsep" enable="eq(-1,true)"/>
+		<setting type="sep"/>
+		<setting label="Audio and Video-Check enabled" type="lsep" enable="eq(-3,true)"/>
+		<setting label="Service check time (minutes): '1'" type="lsep" enable="eq(-4,true)"/>
+		<setting label="Waiting time for the dialog (before stop) (seconds): '30'" type="lsep" enable="eq(-5,true)"/>
+		<setting type="sep"/>
+		<setting label="It doesn't matter, what you set in the other Tabs!" type="lsep" enable="eq(-7,true)"/>
+	</category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="General">
-  		<setting id="debug_mode" label="Debug mode" type="bool" default="false" visible="true"/>
-		<setting id="max_time" label="Maximum allowed playback time before asking to stop" type="slider" default="4" range="1,7" option="int" />
-		<setting id="check_time" label="Service check time (minutes)" type="number" default="5"/>
-		<setting id="waiting_time_dialog" label="Waiting time for the dialog (before stop) - seconds" type="number" default="30"/>
-		<setting id="check_time_next" label="Next check time if dialog is cancelled (minutes)" type="number" default="30"/>
+		<!--<setting id="max_time" label="Maximum allowed playback time before asking to stop" type="slider" default="4" range="1,7" option="int" />-->
+		<setting id="max_time" label="Maximum allowed playback time (minutes) before asking to stop" type="labelenum" values="90|120|150|180|210|240|270|300|330|360|390|420"/>
+		<setting id="check_time" label="Service check time (minutes)" type="labelenum" values="1|3|5|10|15|20|25|30"/>
+		<setting id="waiting_time_dialog" label="Waiting time for the dialog (before stop) - seconds" type="labelenum" values="30|45|60|90|120|150|180"/>
+		<setting id="check_time_next" label="Next check time if dialog is cancelled (minutes)" type="labelenum" values="15|30|45|60|90|120"/>
+		<setting id="audio_change" label="Slow mute audio" type="bool" default="true" visible="true"/>
+		<setting type="sep"/>
+		<setting id="debug_mode" label="Debug mode" type="bool" default="false" visible="true"/>
   </category>  
 </settings>

--- a/service.py
+++ b/service.py
@@ -6,66 +6,149 @@ import xbmcplugin
 import xbmcgui
 import xbmcaddon
 import xbmcvfs
+import json
+
+# changed to "idle.time"
 
 addon_id = 'service.safestop'
 selfAddon = xbmcaddon.Addon(id=addon_id)
 datapath = xbmc.translatePath(selfAddon.getAddonInfo('profile')).decode('utf-8')
 addonfolder = xbmc.translatePath(selfAddon.getAddonInfo('path')).decode('utf-8')
-msgok = xbmcgui.Dialog().ok
-mensagemprogresso = xbmcgui.DialogProgress()
+#msgok = xbmcgui.Dialog().ok
+msgdialogprogress = xbmcgui.DialogProgress()
 
 debug=selfAddon.getSetting('debug_mode')
 check_time = int(selfAddon.getSetting('check_time'))
-max_time = int(selfAddon.getSetting('max_time'))
+max_time_in_minutes = int(selfAddon.getSetting('max_time'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
+audiochange = selfAddon.getSetting('audio_change')
 
 class service:
 	def __init__(self):
 		intro = False
+		next_check = False
 		while not xbmc.abortRequested:
 			if not intro:
-				print "service.safestop"
-				print "Service started..."
+				print "service.safestop: started..."
 				intro = True
-			
+
+			idle_time = xbmc.getGlobalIdleTime()
+			idle_time_in_minutes = int(idle_time)/60
+
 			if xbmc.Player().isPlaying():
-				playback_time = xbmc.Player().getTime()
-				if int(playback_time)/(60*60) >= max_time:
+
+				#if debug == 'true':
+					#print "service.safestop: max_time_in_minutes before calculation: " + str(max_time_in_minutes)
+
+				if next_check == 'true':
+					# add "diff_betwenn_idle_and_check_time" to "idle_time_in_minutes"
+					idle_time_in_minutes += int(diff_betwenn_idle_and_check_time)
+
+				#if debug == 'true':
+					#print "service.safestop: max_time_in_minutes after calculation: " + str(max_time_in_minutes)
+
+				if xbmc.Player().isPlayingAudio():
+					print "service.safestop: Player is playing Audio"
+				elif xbmc.Player().isPlayingVideo():
+					print "service.safestop: Player is playing Video"
+				else:
+					print "service.safestop: Player is playing, but no Audio or Video"
+				
+				#executeJSONRPC(jsonrpccommand)--Execute an JSONRPC command.
+				#jsonrpccommand : string - jsonrpc command to execute.
+				#List of commands -
+				#example:
+				#- response = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "method": "JSONRPC.Introspect", "id": 1 }')
+				
+				#executebuiltin(function)--Execute a built in XBMC function.
+				#function : string - builtin function to execute.
+				#List of functions -http://kodi.wiki/view/List_of_Built_In_Functions 
+				#example:
+				#- xbmc.executebuiltin('RunXBE(c:\avalaunch.xbe)')
+
+				# only for debugging:
+				max_time_in_minutes = 2
+
+				if debug == 'true':
+					print "service.safestop: idle_time: '" + str(idle_time) + "s'; idle_time_in_minutes: '" + str(idle_time_in_minutes) + "'"
+					print "service.safestop: max_time_in_minutes: " + str(max_time_in_minutes)
+				if idle_time_in_minutes >= max_time_in_minutes:
 					if debug == 'true':
-						print "service.safestop: Time exceeds max allowed. Stopping the stream"
-						ret = mensagemprogresso.create('Safe Stop')
-						secs=0
-						percent=0
-						increment = int(100 / time_to_wait)
-						cancelled = False
-						while secs < time_to_wait:
-							secs = secs + 1
-							percent = increment*secs
-							secs_left = str((time_to_wait - secs))
-							remaining_display = str(secs_left) + " seconds left."
-							mensagemprogresso.update(percent,"Cancel to continue watching",remaining_display)
-							xbmc.sleep(1000)
-							if (mensagemprogresso.iscanceled()):
-								cancelled = True
-								break
-						if cancelled == True:
-							check_time = int(selfAddon.getSetting('check_time_next'))
-						else:
-							mensagemprogresso.close()
-							xbmc.Player().stop()
+						print "service.safestop: idle_time exceeds max allowed. Display Progressdialog"
+					ret = msgdialogprogress.create("Safe Stop","Cancel to continue watching")
+					secs=0
+					percent=0
+					# use the multiplier 100 to get better results: 
+					increment = 100*100 / time_to_wait
+					cancelled = False
+					while secs < time_to_wait:
+						secs = secs + 1
+						# divide with 100, to get the right value
+						percent = increment*secs/100
+						#print "service.safestop: percent: " + str(percent)
+						#print "service.safestop: percent_int: " + str(percent_int)
+						secs_left = str((time_to_wait - secs))
+						remaining_display = str(secs_left) + " seconds left."
+						msgdialogprogress.update(percent,"Cancel to continue watching",remaining_display)
+						xbmc.sleep(1000)
+						if (msgdialogprogress.iscanceled()):
+							cancelled = True
+							print "service.safestop: Progressdialog cancelled"
+							break
+					if cancelled == True:
+						print "service.safestop: Progressdialog closed"
+						check_time = int(selfAddon.getSetting('check_time_next'))
+						if debug == 'true':
+							print "service.safestop: cancelled true: check_time: " + str(check_time)
+						# set next_check, so that it opens the dialog after "check_time"
+						next_check = True
+						msgdialogprogress.close()
+					else:
+						print "service.safestop: not cancelled: stopping Player"
+						msgdialogprogress.close()
+
+						# softmute audio before stop playing
+						# source: http://www.kodinerds.net/index.php/Thread/39369-Softmute/
+						# get actual volume
+						if audiochange == 'true':
+							resp = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume"] }, "id": 1}')
+							dct = json.loads(resp)
+							muteVol = 10
+
+							if (dct.has_key("result")) and (dct["result"].has_key("volume")):
+								curVol = dct["result"]["volume"]
+								# print "service.safestop: actual Volume: " + str(curVol)
+								
+								for i in range(curVol - 1, muteVol - 1, -1):
+									# print "service.safestop: set Volume to " + str(i)
+									xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(i) )
+									# move down slowly
+									xbmc.sleep(500)
+
+						# stop player anyway
+						xbmc.Player().stop()
+
+						if audiochange == 'true':
+							xbmc.sleep(2000) # wait 2s before changing the volume back
+							if (dct.has_key("result")) and (dct["result"].has_key("volume")):
+								curVol = dct["result"]["volume"]
+								# print "service.safestop: set Volume to " + str(curVol)
+								# we can move upwards fast, because there is nothing playing
+								xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(curVol) )
+								# xbmc.executebuiltin(SetVolume(percent[,showvolumebar]))
 				else:
 					check_time = int(selfAddon.getSetting('check_time'))
 					if debug == 'true':
 						print "service.safestop: Playing the stream, time does not exceed max limit"
-						
 			else:
 				if debug == 'true':
 					print "service.safestrop: Not playing any media file"
 				check_time = int(selfAddon.getSetting('check_time'))
-
-
+			
+			diff_between_idle_and_check_time = idle_time_in_minutes - check_time
+			if debug == 'true' and next_check == 'true':
+				print "service.safestop: diff_between_idle_and_check_time: " + str(diff_between_idle_and_check_time)
+			
 			xbmc.sleep(check_time*60*1000)
 
 service()
-
-

--- a/service.py
+++ b/service.py
@@ -8,57 +8,157 @@ import xbmcaddon
 import xbmcvfs
 import json
 
-# changed to "idle.time"
+## changed to "idle.time"
+#__addon__ = xbmcaddon.Addon()
+
+## id="service.safestop"
+#__addonid__ = __addon__.getAddonInfo('id')
+
+## name="Safe Stop"
+#__addonname__   = __addon__.getAddonInfo('name')
+
+##__path__ = __addon__.getAddonInfo('path')
+
+##addon_id = 'service.safestop'
+msgdialogprogress = xbmcgui.DialogProgress()
 
 addon_id = 'service.safestop'
 selfAddon = xbmcaddon.Addon(id=addon_id)
 datapath = xbmc.translatePath(selfAddon.getAddonInfo('profile')).decode('utf-8')
 addonfolder = xbmc.translatePath(selfAddon.getAddonInfo('path')).decode('utf-8')
-#msgok = xbmcgui.Dialog().ok
-msgdialogprogress = xbmcgui.DialogProgress()
-
 debug=selfAddon.getSetting('debug_mode')
-check_time = int(selfAddon.getSetting('check_time'))
-max_time_in_minutes = int(selfAddon.getSetting('max_time'))
+## version="2.0.0"
+__version__ = selfAddon.getAddonInfo('version')
+
+check_time = selfAddon.getSetting('check_time')
+check_time_next = int(selfAddon.getSetting('check_time_next'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
 audiochange = selfAddon.getSetting('audio_change')
+audiochangerate = int(selfAddon.getSetting('audio_change_rate'))
+global audio_enable
+audio_enable = str(selfAddon.getSetting('audio_enable'))
+video_enable = str(selfAddon.getSetting('video_enable'))
+max_time_audio = int(selfAddon.getSetting('max_time_audio'))
+max_time_video = int(selfAddon.getSetting('max_time_video'))
+enable_screensaver = selfAddon.getSetting('enable_screensaver')
+
+# Functions:
+def _log( message ):
+		print addon_id + ": " + str(message)
+
+# print the actual playing file in DEBUG-mode
+def print_act_playing_file():
+		if debug == 'true':
+			actPlayingFile = xbmc.Player().getPlayingFile()
+			_log ( "DEBUG: File: " + str(actPlayingFile) )
+
+# wait for abort - xbmc.sleep or time.sleep doesn't work
+# and prevents Kodi from exiting
+def do_next_check( iTimeToWait ):
+	if debug == 'true':
+		_log ( "DEBUG: next check in " + str(iTimeToWait) + " min" )
+	if xbmc.Monitor().waitForAbort(int(iTimeToWait)*60):
+		exit()
 
 class service:
 	def __init__(self):
-		intro = False
+		FirstCycle = True
 		next_check = False
-		while not xbmc.abortRequested:
-			if not intro:
-				print "service.safestop: started..."
-				intro = True
+
+		while True:
+			if FirstCycle:
+				# Variables:
+				enable_audio = audio_enable
+				enable_video = video_enable
+				maxaudio_time_in_minutes = max_time_audio
+				maxvideo_time_in_minutes = max_time_video
+				iCheckTime = check_time
+				
+				_log ( "started ... (" + str(__version__) + ")" )
+				if debug == 'true':
+					_log ( "DEBUG: ################################################################" )
+					_log ( "DEBUG: Settings in Kodi:" )
+					_log ( 'DEBUG: enable_audio: ' + enable_audio )
+					_log ( "DEBUG: maxaudio_time_in_minutes: " + str(maxaudio_time_in_minutes) )
+					_log ( "DEBUG: enable_video: " + str(enable_video) )
+					_log ( "DEBUG: maxvideo_time_in_minutes: " + str(maxvideo_time_in_minutes) )
+					_log ( "DEBUG: check_time: " + str(iCheckTime) )
+					_log ( "DEBUG: ################################################################" )
+					# Set this low values for easier debugging!
+					_log ( "DEBUG: debug is enabled! Override Settings:" )
+					enable_audio = 'true'
+					_log ( "DEBUG: -> enable_audio: " + str(enable_audio) )
+					maxaudio_time_in_minutes = 1
+					_log ( "DEBUG: -> maxaudio_time_in_minutes: " + str(maxaudio_time_in_minutes) )
+					enable_video = 'true'
+					_log ( "DEBUG: -> enable_video: " + str(enable_audio) )
+					maxvideo_time_in_minutes = 1
+					_log ( "DEBUG: -> maxvideo_time_in_minutes: " + str(maxvideo_time_in_minutes) )
+					iCheckTime = 1
+					_log ( "DEBUG: -> check_time: " + str(iCheckTime) )
+					_log ( "DEBUG: ----------------------------------------------------------------" )
+
+				# wait 15s before start to let Kodi finish the intro-movie
+				if xbmc.Monitor().waitForAbort(15):
+					break
+
+				max_time_in_minutes = -1
+				FirstCycle = False
 
 			idle_time = xbmc.getGlobalIdleTime()
 			idle_time_in_minutes = int(idle_time)/60
 
 			if xbmc.Player().isPlaying():
 
-				#if debug == 'true':
-					#print "service.safestop: max_time_in_minutes before calculation: " + str(max_time_in_minutes)
+				if debug == 'true' and max_time_in_minutes == -1:
+					_log ( "DEBUG: max_time_in_minutes before calculation: " + str(max_time_in_minutes) )
 
 				if next_check == 'true':
 					# add "diff_betwenn_idle_and_check_time" to "idle_time_in_minutes"
 					idle_time_in_minutes += int(diff_betwenn_idle_and_check_time)
 
-				#if debug == 'true':
-					#print "service.safestop: max_time_in_minutes after calculation: " + str(max_time_in_minutes)
+				if debug == 'true' and max_time_in_minutes == -1:
+					_log ( "DEBUG: max_time_in_minutes after calculation: " + str(max_time_in_minutes) )
 
 				if xbmc.Player().isPlayingAudio():
-					print "service.safestop: Player is playing Audio"
+					if enable_audio == 'true':
+						if debug == 'true':
+							_log ( "DEBUG: enable_audio is true" )
+							print_act_playing_file()
+						what_is_playing = "audio"
+						max_time_in_minutes = maxaudio_time_in_minutes
+					else:
+						if debug == 'true':
+							_log ( "DEBUG: Player is playing Audio, but check is disabled" )
+						do_next_check(iCheckTime)
+						continue
+
 				elif xbmc.Player().isPlayingVideo():
-					print "service.safestop: Player is playing Video"
-				else:
-					print "service.safestop: Player is playing, but no Audio or Video"
+					if enable_video == 'true':
+						if debug == 'true':
+							_log ( "DEBUG: enable_video is true" )
+							print_act_playing_file()
+						what_is_playing = "video"
+						max_time_in_minutes = maxaudio_time_in_minutes
+					else:
+						if debug == 'true':
+							_log ( "DEBUG: Player is playing Video, but check is disabled" )
+						do_next_check(iCheckTime)
+						continue
+					
+				### ToDo:
+				# expand it with RetroPlayer for playing Games!!!
 				
-				#executeJSONRPC(jsonrpccommand)--Execute an JSONRPC command.
-				#jsonrpccommand : string - jsonrpc command to execute.
-				#List of commands -
-				#example:
-				#- response = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "method": "JSONRPC.Introspect", "id": 1 }')
+				else:
+					if debug == 'true':
+							_log ( "DEBUG: Player is playing, but no Audio or Video" )
+							print_act_playing_file()
+					what_is_playing = "other"
+					do_next_check(iCheckTime)
+					continue
+					
+				if debug == 'true':
+					_log ( "DEBUG: what_is_playing: " + str(what_is_playing) )
 				
 				#executebuiltin(function)--Execute a built in XBMC function.
 				#function : string - builtin function to execute.
@@ -66,45 +166,45 @@ class service:
 				#example:
 				#- xbmc.executebuiltin('RunXBE(c:\avalaunch.xbe)')
 
-				# only for debugging:
-				max_time_in_minutes = 2
-
 				if debug == 'true':
-					print "service.safestop: idle_time: '" + str(idle_time) + "s'; idle_time_in_minutes: '" + str(idle_time_in_minutes) + "'"
-					print "service.safestop: max_time_in_minutes: " + str(max_time_in_minutes)
-				if idle_time_in_minutes >= max_time_in_minutes:
+					_log ( "DEBUG: idle_time: '" + str(idle_time) + "s'; idle_time_in_minutes: '" + str(idle_time_in_minutes) + "'" )
+					_log ( "DEBUG: max_time_in_minutes: " + str(max_time_in_minutes) )
+				
+				# only display the Progressdialog, if audio or video is enabled AND idle limit is reached
+				
+				# Check if what_is_playing is not "other" and idle time exceeds limit
+				if ( what_is_playing != "other" and idle_time_in_minutes >= max_time_in_minutes ):
+
 					if debug == 'true':
-						print "service.safestop: idle_time exceeds max allowed. Display Progressdialog"
-					ret = msgdialogprogress.create("Safe Stop","Cancel to continue watching")
+						_log ( "DEBUG: idle_time exceeds max allowed. Display Progressdialog" )
+
+					ret = msgdialogprogress.create("Safe Stop","Cancel to continue playing")
 					secs=0
 					percent=0
-					# use the multiplier 100 to get better results: 
+					# use the multiplier 100 to get better %/calculation 
 					increment = 100*100 / time_to_wait
 					cancelled = False
 					while secs < time_to_wait:
 						secs = secs + 1
 						# divide with 100, to get the right value
 						percent = increment*secs/100
-						#print "service.safestop: percent: " + str(percent)
-						#print "service.safestop: percent_int: " + str(percent_int)
 						secs_left = str((time_to_wait - secs))
 						remaining_display = str(secs_left) + " seconds left."
-						msgdialogprogress.update(percent,"Cancel to continue watching",remaining_display)
+						msgdialogprogress.update(percent,"Cancel to continue playing",remaining_display)
 						xbmc.sleep(1000)
 						if (msgdialogprogress.iscanceled()):
 							cancelled = True
-							print "service.safestop: Progressdialog cancelled"
+							if debug == 'true':
+								_log ( "DEBUG: Progressdialog cancelled" )
 							break
 					if cancelled == True:
-						print "service.safestop: Progressdialog closed"
-						check_time = int(selfAddon.getSetting('check_time_next'))
-						if debug == 'true':
-							print "service.safestop: cancelled true: check_time: " + str(check_time)
-						# set next_check, so that it opens the dialog after "check_time"
+						iCheckTime = check_time_next
+						_log ( "Progressdialog cancelled, next check in " + str(iCheckTime) + " min" )
+						# set next_check, so that it opens the dialog after "iCheckTime"
 						next_check = True
 						msgdialogprogress.close()
 					else:
-						print "service.safestop: not cancelled: stopping Player"
+						_log ( "Progressdialog not cancelled: stopping Player" )
 						msgdialogprogress.close()
 
 						# softmute audio before stop playing
@@ -117,38 +217,44 @@ class service:
 
 							if (dct.has_key("result")) and (dct["result"].has_key("volume")):
 								curVol = dct["result"]["volume"]
-								# print "service.safestop: actual Volume: " + str(curVol)
 								
 								for i in range(curVol - 1, muteVol - 1, -1):
-									# print "service.safestop: set Volume to " + str(i)
-									xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(i) )
+									#xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(i) )
+									xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (i))
 									# move down slowly
-									xbmc.sleep(500)
+									xbmc.sleep(audiochangerate)
 
 						# stop player anyway
+						xbmc.sleep(5000) # wait 5s before stopping
 						xbmc.Player().stop()
 
 						if audiochange == 'true':
 							xbmc.sleep(2000) # wait 2s before changing the volume back
 							if (dct.has_key("result")) and (dct["result"].has_key("volume")):
 								curVol = dct["result"]["volume"]
-								# print "service.safestop: set Volume to " + str(curVol)
+								# _log ( "set Volume to " + str(curVol) )
 								# we can move upwards fast, because there is nothing playing
-								xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(curVol) )
-								# xbmc.executebuiltin(SetVolume(percent[,showvolumebar]))
+								#xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.SetVolume", "params": { "volume": %d }, "id": 1}' %(curVol) )
+								xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (curVol))
+
+						if enable_screensaver == 'true':
+							if debug == 'true':
+								_log ( "DEBUG: Activating screensaver" )
+							xbmc.executebuiltin('ActivateScreensaver')
 				else:
-					check_time = int(selfAddon.getSetting('check_time'))
 					if debug == 'true':
-						print "service.safestop: Playing the stream, time does not exceed max limit"
+						_log ( "DEBUG: Playing the stream, time does not exceed max limit" )
 			else:
 				if debug == 'true':
-					print "service.safestrop: Not playing any media file"
-				check_time = int(selfAddon.getSetting('check_time'))
+					_log ( "DEBUG: Not playing any media file" )
+				# reset max_time_in_minutes
+				max_time_in_minutes = -1
 			
-			diff_between_idle_and_check_time = idle_time_in_minutes - check_time
+			diff_between_idle_and_check_time = idle_time_in_minutes - int(iCheckTime)
+			
 			if debug == 'true' and next_check == 'true':
-				print "service.safestop: diff_between_idle_and_check_time: " + str(diff_between_idle_and_check_time)
-			
-			xbmc.sleep(check_time*60*1000)
+				_log ( "DEBUG: diff_between_idle_and_check_time: " + str(diff_between_idle_and_check_time) )
+
+			do_next_check(iCheckTime)
 
 service()


### PR DESCRIPTION
new features:
- changed to "idle"
  it works with "Live-TV" also. If the user doesn't do anything for $check_time the dialog pops up
- separate Audio and Video supervision and check_time
  you can switch Audio and Video Supervision off separately. This is useful for Partys, where you don't want the Music to stop after 2,5h Wink
- option to slowly mute Audio before stopping
  Who didn't wakeup in front of the TV because of the abrupt volume change if it stops playing 
- option to enable the screensaver after stoppingPle
- improved activating/deactivating of the plugin
  You don't have to restart Kodi to make the new settings work. Just reactivate the Addon

Please feel free to modify, change or improve the code. This is my first work with python, so there maybe some improvements ;)
