### PR TITLE
Fixes for supervision_mode and maxvideo_time_in_minutes

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -17,7 +17,7 @@
 		<setting id="max_time_video" label="30013" type="labelenum" default="150" enable="eq(-3,true)" values="30|60|90|120|150|180|210|240|270|300|330|360|390|420"/>
 		<setting id="max_time_audio" label="30014" type="labelenum" default="150" enable="eq(-3,true)" values="30|60|90|120|150|180|210|240|270|300|330|360|390|420"/>
 		<setting label="30024" type="lsep"/>
-		<setting id="supervision_mode" label="30024" type="labelenum" default="0" values="Always | Specific Time"/>
+		<setting id="supervision_mode" label="30024" type="enum" default="0" values="Always|Specific Time"/>
 		<setting label="30025" type="text" id="hour_start_sup" visible="eq(-1,1)" default="00:00"/>
 		<setting label="30026" type="text" id="hour_end_sup" visible="eq(-2,1)" default="00:00"/>
 	</category>

--- a/service.py
+++ b/service.py
@@ -193,7 +193,7 @@ class service:
                                 _log ( "DEBUG: enable_video is true" )
                                 print_act_playing_file()
                             what_is_playing = "video"
-                            max_time_in_minutes = maxaudio_time_in_minutes
+                            max_time_in_minutes = maxvideo_time_in_minutes
                         else:
                             if debug == 'true':
                                 _log ( "DEBUG: Player is playing Video, but check is disabled" )


### PR DESCRIPTION
I noticed that the timer wasn't working for me when supervision_mode was set to always. This was because a labelenum was used in the settings.xml and in service.py it was being compared to '0' so I changed the setting to an enum and it now works.
I also found that the maxaudio_time_in_minutes was being used for video as well as audio so I fixed that too.
