### PR TITLE
Fixed a spelling error in service.py that broke next_check

### DIFF
--- a/service.py
+++ b/service.py
@@ -168,8 +168,8 @@ class service:
                         _log ( "DEBUG: max_time_in_minutes before calculation: " + str(max_time_in_minutes) )
 
                     if next_check == 'true':
-                        # add "diff_betwenn_idle_and_check_time" to "idle_time_in_minutes"
-                        idle_time_in_minutes += int(diff_betwenn_idle_and_check_time)
+                        # add "diff_between_idle_and_check_time" to "idle_time_in_minutes"
+                        idle_time_in_minutes += int(diff_between_idle_and_check_time)
 
                     if debug == 'true' and max_time_in_minutes == -1:
                         _log ( "DEBUG: max_time_in_minutes after calculation: " + str(max_time_in_minutes) )


### PR DESCRIPTION
After cancelling the dialog, the service appeared not to check again. It was just a typo that I corrected. It has been tested and works now.
