### PR TITLE
Human friendly audio interval timer

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.sleeptimer"
        name="Sleep Timer"
-      version="2.0.8"
+      version="2.0.9"
       provider-name="enen92, Solo0815">
     <requires>
 		<import addon="xbmc.addon" version="14.0.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.sleeptimer"
        name="Sleep Timer"
-      version="2.0.7"
+      version="2.0.8"
       provider-name="enen92, Solo0815">
     <requires>
 		<import addon="xbmc.addon" version="14.0.0"/>
-		<import addon="xbmc.python" version="2.19.0"/>
+		<import addon="xbmc.python" version="3.0.0"/>
     </requires>
     <extension point="xbmc.service" library="service.py" start="login"/>
     <extension point="xbmc.addon.metadata">

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.sleeptimer"
        name="Sleep Timer"
-      version="2.0.9"
+      version="2.0.10"
       provider-name="enen92, Solo0815">
     <requires>
 		<import addon="xbmc.addon" version="14.0.0"/>

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -39,7 +39,7 @@ msgid "General"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Time between 1% volume change  (millisec)"
+msgid "Time it takes to reach 0% volume (minutes)"
 msgstr ""
 
 msgctxt "#30007"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -129,3 +129,7 @@ msgstr ""
 msgctxt "#30028"
 msgid "Specific Time"
 msgstr ""
+
+msgctxt "#30029"
+msgid "Set the minimum volume %"
+msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -38,8 +38,8 @@ msgid "General"
 msgstr "Geral"
 
 msgctxt "#30006"
-msgid "Time between 1% volume change  (millisec)"
-msgstr "Tempo entre a alteração de 1% volume (millisec)"
+msgid "Time it takes to reach 0% volume (minutes)"
+msgstr "Tempo que leva para atingir o volume de 0% (minutos)"
 
 msgctxt "#30007"
 msgid "Next check time if dialog is cancelled (minutes)"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -128,3 +128,7 @@ msgstr "Sempre"
 msgctxt "#30028"
 msgid "Specific Time"
 msgstr "Tempo especifico"
+
+msgctxt "#30029"
+msgid "Set the minimum volume %"
+msgstr "Defina o volume mínimo %"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,7 @@
 		<setting id="check_time" label="30002" default="5" type="slider" range="1,5,120" option="int"/>
 		<setting id="waiting_time_dialog" label="30003" type="slider" default="60" range="30,5,180" option="int"/>
 		<setting id="audio_change" label="30004" type="bool" default="true" visible="true"/>
-		<setting id="audio_change_rate" label="30006" enable="eq(-1,true)" type="slider" default="500" range="50,50,3000" option="int"/>
+		<setting id="audio_interval_length" label="30006" enable="eq(-1,true)" type="slider" default="1" range="1,1,120" option="int"/>
 		<setting id="check_time_next" label="30007" type="slider" default="30" range="15,10,120" option="int"/>
 		<setting id="enable_screensaver" label="30008" type="bool" default="false" visible="true"/>
 	     <setting id="custom_cmd" label="30022" type="bool" default="false" visible="true"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
 		<setting id="waiting_time_dialog" label="30003" type="slider" default="60" range="30,5,180" option="int"/>
 		<setting id="audio_change" label="30004" type="bool" default="true" visible="true"/>
 		<setting id="audio_interval_length" label="30006" enable="eq(-1,true)" type="slider" default="1" range="1,1,120" option="int"/>
+		<setting id="mute_volume" label="30029" enable="eq(-2,true)" type="slider" default="10" range="1,1,100" visible="true" option="int"/>
 		<setting id="check_time_next" label="30007" type="slider" default="30" range="15,10,120" option="int"/>
 		<setting id="enable_screensaver" label="30008" type="bool" default="false" visible="true"/>
 	     <setting id="custom_cmd" label="30022" type="bool" default="false" visible="true"/>

--- a/service.py
+++ b/service.py
@@ -30,8 +30,8 @@ msgdialogprogress = xbmcgui.DialogProgress()
 
 addon_id = 'service.sleeptimer'
 selfAddon = xbmcaddon.Addon(addon_id)
-datapath = xbmc.translatePath(selfAddon.getAddonInfo('profile')).decode('utf-8')
-addonfolder = xbmc.translatePath(selfAddon.getAddonInfo('path')).decode('utf-8')
+datapath = xbmc.translatePath(selfAddon.getAddonInfo('profile'))
+addonfolder = xbmc.translatePath(selfAddon.getAddonInfo('path'))
 debug=selfAddon.getSetting('debug_mode')
 
 __version__ = selfAddon.getAddonInfo('version')

--- a/service.py
+++ b/service.py
@@ -39,6 +39,7 @@ check_time = selfAddon.getSetting('check_time')
 check_time_next = int(selfAddon.getSetting('check_time_next'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
 audiochange = selfAddon.getSetting('audio_change')
+muteVol = int(selfAddon.getSetting('mute_volume'))
 audiointervallength = int(selfAddon.getSetting('audio_interval_length'))
 global audio_enable
 audio_enable = str(selfAddon.getSetting('audio_enable'))
@@ -261,7 +262,6 @@ class service:
                             if audiochange == 'true':
                                 resp = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Application.GetProperties", "params": { "properties": [ "volume"] }, "id": 1}')
                                 dct = json.loads(resp)
-                                muteVol = 10
 
                                 if ("result" in dct) and ("volume" in dct["result"]):
                                     curVol = dct["result"]["volume"]

--- a/service.py
+++ b/service.py
@@ -268,8 +268,9 @@ class service:
 
                                     for i in range(curVol - 1, muteVol - 1, -1):
                                         xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (i))
-                                        # move down slowly
-                                        xbmc.sleep(audiointervallength * 600)
+                                        # move down slowly ((total mins / steps) * ms in a min)
+                                        # (curVol-muteVol) runs the full timer where a user might control their volume via kodi instead of cutting it short when assuming a set volume of 100%
+                                        xbmc.sleep(round(audiointervallength / (curVol - muteVol) * 60000))
 
                             # stop player anyway
                             monitor.waitForAbort(5) # wait 5s before stopping

--- a/service.py
+++ b/service.py
@@ -239,7 +239,7 @@ class service:
                             percent = increment*secs/100
                             secs_left = str((time_to_wait - secs))
                             remaining_display = str(secs_left) + " seconds left."
-                            msgdialogprogress.update(percent,translate(30001),remaining_display)
+                            msgdialogprogress.update(int(percent),translate(30001))
                             xbmc.sleep(1000)
                             if (msgdialogprogress.iscanceled()):
                                 cancelled = True
@@ -263,7 +263,7 @@ class service:
                                 dct = json.loads(resp)
                                 muteVol = 10
 
-                                if (dct.has_key("result")) and (dct["result"].has_key("volume")):
+                                if ("result" in dct) and ("volume" in dct["result"]):
                                     curVol = dct["result"]["volume"]
 
                                     for i in range(curVol - 1, muteVol - 1, -1):
@@ -277,7 +277,7 @@ class service:
 
                             if audiochange == 'true':
                                 monitor.waitForAbort(2) # wait 2s before changing the volume back
-                                if (dct.has_key("result")) and (dct["result"].has_key("volume")):
+                                if ("result" in dct) and ("volume" in dct["result"]):
                                     curVol = dct["result"]["volume"]
                                     # we can move upwards fast, because there is nothing playing
                                     xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (curVol))

--- a/service.py
+++ b/service.py
@@ -39,7 +39,7 @@ check_time = selfAddon.getSetting('check_time')
 check_time_next = int(selfAddon.getSetting('check_time_next'))
 time_to_wait = int(selfAddon.getSetting('waiting_time_dialog'))
 audiochange = selfAddon.getSetting('audio_change')
-audiochangerate = int(selfAddon.getSetting('audio_change_rate'))
+audiointervallength = int(selfAddon.getSetting('audio_interval_length'))
 global audio_enable
 audio_enable = str(selfAddon.getSetting('audio_enable'))
 video_enable = str(selfAddon.getSetting('video_enable'))
@@ -269,7 +269,7 @@ class service:
                                     for i in range(curVol - 1, muteVol - 1, -1):
                                         xbmc.executebuiltin('SetVolume(%d,showVolumeBar)' % (i))
                                         # move down slowly
-                                        xbmc.sleep(audiochangerate)
+                                        xbmc.sleep(audiointervallength * 600)
 
                             # stop player anyway
                             monitor.waitForAbort(5) # wait 5s before stopping


### PR DESCRIPTION
How long did 3000ms interval take before? Who cares about the interval itself.
I find this method of setting the interval to be a lot better for humans. Humans are more concerned with how long the interval will run.
This also has the benefit of a shorter slider (1 to 120 instead of 50 to 3000) while allowing a longer timer (max of 2 hours instead of a max of 50 mins)

Unsure about Portuguese string. I used google translate.